### PR TITLE
Prevent TypeError on null response in eventClient.send callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/openai-observability",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "private": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/eventsClient.ts
+++ b/src/eventsClient.ts
@@ -54,11 +54,15 @@ export const createEventClient = (
       eventBatch.addEvent(event);
     });
 
-    eventClient.send(eventBatch, (error, { statusCode, statusMessage }) => {
+    eventClient.send(eventBatch, (error, response) => {
       if (error) {
         console.error(error);
-      } else if (statusCode !== 200) {
-        console.error(`Error sending event: ${statusCode} ${statusMessage}`);
+      } else if (response) {
+        const { statusCode, statusMessage } = response;
+
+        if (statusCode !== 200) {
+          console.error(`Error sending event: ${statusCode} ${statusMessage}`);
+        }
       }
     });
   };


### PR DESCRIPTION
## Issue Addressed
This pull request resolves an issue where an unreachable collector endpoint leads to an unrecoverable TypeError. This occurs when the eventClient.send callback attempts to destructure a null response object. The issue is detailed in the repository's issue tracker #28.

## Problem Overview
When the collector endpoint is unreachable, the telemetry client's callback is invoked with a null response. The existing callback implementation destructures this response, resulting in a TypeError:
`TypeError: Cannot destructure property 'statusCode' of 'object null' as it is null.`

## Implemented Solution
The callback function has been updated to include a check for a valid response object before destructuring:

```
eventClient.send(eventBatch, (error, response) => {
  if (error) {
    console.error(error);
  } else if (response) {
    const { statusCode, statusMessage } = response;

    if (statusCode !== 200) {
      console.error(`Error sending event: ${statusCode} ${statusMessage}`);
    }
  }
});
```
## Testing
The solution has been tested by simulating an unreachable collector endpoint, confirming that the module no longer encounters a TypeError and handles the error appropriately.

